### PR TITLE
Set up application class and service

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,9 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "com.squareup.retrofit2:retrofit:2.4.0"
 }
+
 repositories {
     mavenCentral()
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.squareup.retrofit2:retrofit:2.4.0"
+    implementation 'com.squareup.retrofit2:converter-gson:2.1.0'
 }
 
 repositories {

--- a/app/src/main/java/space/straylense/myapplication/NMApplication.kt
+++ b/app/src/main/java/space/straylense/myapplication/NMApplication.kt
@@ -1,0 +1,29 @@
+package space.straylense.myapplication
+
+import android.app.Application
+
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class NMApplication : Application() {
+
+    var instance: NMApplication? = null
+        private set
+    var service: Service? = null
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+        setupService()
+    }
+
+    private fun setupService() {
+        val retrofit = Retrofit.Builder()
+                .baseUrl(getString(R.string.base_url))
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+        service = retrofit.create(Service::class.java)
+    }
+
+}

--- a/app/src/main/java/space/straylense/myapplication/Service.kt
+++ b/app/src/main/java/space/straylense/myapplication/Service.kt
@@ -1,0 +1,15 @@
+package space.straylense.myapplication
+
+import com.google.gson.JsonObject
+
+import retrofit2.Call
+import retrofit2.http.GET
+
+interface Service {
+
+    @get:GET("2/events?&sign=true&photo-host=public&group_urlname=New-Mexico-Android-Developers&page=20")
+    val events: Call<JsonObject>
+
+    // TODO Setup post request to RSVP
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
   <string name="nav_header_title">Android Studio</string>
   <string name="nav_header_subtitle">android.studio@android.com</string>
   <string name="nav_header_desc">Navigation header</string>
+    <string name="base_url">https://api.meetup.com/</string>
 </resources>


### PR DESCRIPTION
Created an application class called NMApplication (feel free to change this, just 'Application' can lead to confusion with the class its extending though) and a Service class capable of making calls to the Meetups API. Imported retrofit and retrofit:converter-gson dependencies. 

You can see an example of an activity using the service to make a call on the 'working' branch of my fork ([activity](https://github.com/jscpeterson/NMDevAppClient/blob/working/app/src/main/java/space/straylense/myapplication/TestActivity.kt) and [layout](https://github.com/jscpeterson/NMDevAppClient/blob/working/app/src/main/res/layout/activity_test.xml))

This will resolve #6.